### PR TITLE
Missing return statement

### DIFF
--- a/Sparrow3D.vcproj
+++ b/Sparrow3D.vcproj
@@ -41,7 +41,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="0"
-				PreprocessorDefinitions="BUILDING_DLL;WIN32;X86CPU"
+				PreprocessorDefinitions="BUILDING_DLL;WIN32;X86CPU;_CRT_SECURE_NO_WARNINGS"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
 				RuntimeLibrary="3"
@@ -116,7 +116,7 @@
 				Name="VCCLCompilerTool"
 				Optimization="2"
 				EnableIntrinsicFunctions="true"
-				PreprocessorDefinitions="BUILDING_DLL;WIN32;X86CPU"
+				PreprocessorDefinitions="BUILDING_DLL;WIN32;X86CPU;_CRT_SECURE_NO_WARNINGS"
 				RuntimeLibrary="2"
 				EnableFunctionLevelLinking="true"
 				UsePrecompiledHeader="0"

--- a/sparrowCore.c
+++ b/sparrowCore.c
@@ -1121,7 +1121,7 @@ PREFIX SDL_Surface* spLoadSurface( char* name )
 		return c->surface;
 	}
 	else
-		spLoadUncachedSurface(name);
+		return spLoadUncachedSurface(name);
 }
 
 PREFIX void spEnableCaching()

--- a/sparrowSprite.c
+++ b/sparrowSprite.c
@@ -344,7 +344,6 @@ PREFIX spSpriteCollectionPointer spLoadSpriteCollection(char* filename,SDL_Surfa
 			for (j = strlen(value)-1;value[j]==' ' && j>=0;j--);
 			value[j+1] = 0;
 			int x,y,n;
-			SDL_Surface* s;
 			switch (keyword)
 			{
 				case 1: //"default"


### PR DESCRIPTION
Means it's possible spLoadSurface can return NULL under Visual Studio build if not caching.
Also removed an unused variable, and added a VC++ define to ignore "safe" file operation warnings
